### PR TITLE
Enable automatic carousel scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,10 @@
     function stopAuto() {
         clearInterval(auto);
     }
-    carrusel.addEventListener('mouseenter', startAuto);
-    carrusel.addEventListener('mouseleave', stopAuto);
+    startAuto();
+    carrusel.addEventListener('mouseenter', stopAuto);
+    carrusel.addEventListener('touchstart', stopAuto);
+    carrusel.addEventListener('mouseleave', startAuto);
+    carrusel.addEventListener('touchend', startAuto);
 </script>
 </html>


### PR DESCRIPTION
## Summary
- start the carousel auto-scroll as soon as the page loads
- pause auto-scroll on mouse/touch interaction and resume when interaction ends

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68487bf90aa8832eb6d9f371846c3e25